### PR TITLE
Fixed POS State Recognition and Critical Alerts Filtering

### DIFF
--- a/src/Database/migrations/2025_10_01_000015_add_state_to_starbase_fuel_history.php
+++ b/src/Database/migrations/2025_10_01_000015_add_state_to_starbase_fuel_history.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Migration to add dedicated state column to starbase_fuel_history
+ * 
+ * Previously state was only stored in metadata JSON column.
+ * This migration:
+ * 1. Adds a dedicated state column for better querying
+ * 2. Migrates existing state data from metadata->state to the new column
+ * 3. Adds an index for performance
+ */
+class AddStateToStarbaseFuelHistory extends Migration
+{
+    public function up()
+    {
+        // Add state column to starbase_fuel_history
+        Schema::table('starbase_fuel_history', function (Blueprint $table) {
+            $table->tinyInteger('state')->nullable()->after('system_id')->comment('POS state: 0=unanchored, 1=offline, 2=onlining, 3=reinforced, 4=online');
+            $table->index('state');
+        });
+        
+        // Migrate existing state data from metadata to new column
+        // Note: SeAT stores state as STRING in metadata (e.g., "online", "offline")
+        // We need to convert these strings to integers
+        try {
+            $stateMap = [
+                'unanchored' => 0,
+                'offline' => 1,
+                'onlining' => 2,
+                'reinforced' => 3,
+                'online' => 4,
+                'unanchoring' => 5,
+            ];
+            
+            // Get all records with state in metadata
+            $records = DB::table('starbase_fuel_history')
+                ->whereNotNull('metadata')
+                ->whereRaw("JSON_EXTRACT(metadata, '$.state') IS NOT NULL")
+                ->select('id', DB::raw("JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state')) as state_string"))
+                ->get();
+            
+            $updated = 0;
+            foreach ($records as $record) {
+                $stateString = strtolower(trim($record->state_string));
+                $stateInt = $stateMap[$stateString] ?? null;
+                
+                if ($stateInt !== null) {
+                    DB::table('starbase_fuel_history')
+                        ->where('id', $record->id)
+                        ->update(['state' => $stateInt]);
+                    $updated++;
+                }
+            }
+            
+            \Illuminate\Support\Facades\Log::info("Migration: Migrated {$updated} state values from metadata to state column");
+        } catch (\Exception $e) {
+            \Illuminate\Support\Facades\Log::warning('Migration: Could not migrate state from metadata: ' . $e->getMessage());
+            // Don't fail migration if this fails - state will be populated on next tracking run
+        }
+    }
+
+    public function down()
+    {
+        Schema::table('starbase_fuel_history', function (Blueprint $table) {
+            $table->dropIndex(['state']);
+            $table->dropColumn('state');
+        });
+    }
+}

--- a/src/Models/StarbaseFuelHistory.php
+++ b/src/Models/StarbaseFuelHistory.php
@@ -19,6 +19,7 @@ class StarbaseFuelHistory extends Model
         'tower_type_id',
         'starbase_name',
         'system_id',
+        'state', // POS state: 0=unanchored, 1=offline, 2=onlining, 3=reinforced, 4=online
         // Fuel blocks
         'fuel_blocks_quantity',
         'fuel_days_remaining',
@@ -50,6 +51,7 @@ class StarbaseFuelHistory extends Model
     ];
     
     protected $casts = [
+        'state' => 'integer',
         'fuel_blocks_quantity' => 'integer',
         'fuel_days_remaining' => 'float',
         'fuel_blocks_used' => 'integer',
@@ -166,5 +168,65 @@ class StarbaseFuelHistory extends Model
         } else {
             return 'good';
         }
+    }
+    
+    /**
+     * Get state name from state integer
+     * 
+     * @return string State name
+     */
+    public function getStateName()
+    {
+        $stateMap = [
+            0 => 'Unanchored',
+            1 => 'Offline',
+            2 => 'Onlining',
+            3 => 'Reinforced',
+            4 => 'Online',
+        ];
+        
+        return $stateMap[$this->state] ?? 'Unknown';
+    }
+    
+    /**
+     * Get state badge class for styling
+     * 
+     * @return string CSS class for badge
+     */
+    public function getStateBadgeClass()
+    {
+        $stateClassMap = [
+            0 => 'badge-secondary',  // Unanchored
+            1 => 'badge-danger',     // Offline
+            2 => 'badge-info',       // Onlining
+            3 => 'badge-warning',    // Reinforced
+            4 => 'badge-success',    // Online
+        ];
+        
+        return $stateClassMap[$this->state] ?? 'badge-secondary';
+    }
+    
+    /**
+     * Check if POS is online (state = 4)
+     */
+    public function isOnline()
+    {
+        return $this->state === 4;
+    }
+    
+    /**
+     * Check if POS is reinforced (state = 3)
+     */
+    public function isReinforced()
+    {
+        return $this->state === 3;
+    }
+    
+    /**
+     * Check if POS is offline (state = 1)
+     */
+    public function isOffline()
+    {
+        return $this->state === 1;
     }
 }


### PR DESCRIPTION
## 🐛 Bug Fixes

### Fixed POS State Recognition and Critical Alerts Filtering

**Issue:** POSes were not appearing correctly in critical alerts and notifications regardless of their state.

**What's Fixed:**

- **Fixed POS state recognition** - Plugin now correctly identifies POS states (unanchored, offline, onlining, reinforced, online, unanchoring)

- **Critical alerts page filtering** - Critical alerts page will now only show POSes that are **online** or **reinforced** and actively consuming fuel. POSes in other states (offline, unanchored, etc.) are excluded from alerts as they do not consume fuel.

- **Notification filtering** - Discord/Slack notifications will now only be sent for POSes in **online** or **reinforced** states. Any other state will be ignored.

- **Added POS state badge** - Control tower list now displays a badge showing the current state of each POS for better visibility.

- **Added state validation checks** - Enhanced validation to ensure state recognition is accurate throughout the plugin.

---

**State Behavior:**
- **Online (state 4)** - POS is operational and consuming fuel → Alerts enabled
- **Reinforced (state 3)** - POS is in reinforced mode and consuming fuel → Alerts enabled
- **Offline (state 1)** - POS is anchored but offline → Alerts disabled (no fuel consumption)
- **Unanchored (state 0)** - POS is not deployed → Alerts disabled
- **Onlining (state 2)** - POS is coming online → Alerts disabled
- **Unanchoring (state 5)** - POS is being unanchored → Alerts disabled

---