### PR TITLE
1.0.10

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,41 @@ Each version entry lists key changes for easier reference and upgrade planning.
 
 ---
 
-## 🆕 Version 1.0.9 — *November 2025*
+## 🆕 Version 1.0.10 — *November 2025*
+
+### Added
+- Multiple webhook support with per-webhook configuration (corporation filters, location filters, role mentions)
+- Zero strontium behavior handling for POSes (proper critical alerts and status detection)
+- Status-based POS notifications (good → warning → critical transitions with optional reminders)
+- Final 1-hour alert for POSes before going offline
+- `simulate-consumption` command for rapid fuel consumption testing
+- Webhook test button in settings for connectivity verification
+- Enhanced reserve tracking with nested Office container support
+
+### Changed
+- Renamed "Recent Refuel Events" section to "Fuel Withdrawals" for clarity
+- Fuel Withdrawals now only shows Upwell structures (excludes POS and Metenox)
+- Enhanced refuel event detection logic
+- Updated help documentation with corrected command schedules
+- `track-fuel` command now documented as handling both fuel bays and reserves
+- `analyze-consumption` command now includes `--structure` and `--corporation` options
+
+### Fixed
+- POS and Metenox entries incorrectly appearing in Fuel Withdrawals section
+- Incorrect command schedules in help documentation (analyze-consumption)
+- Duplicate "Track Fuel Reserves" section in help documentation
+- Zero strontium alert triggers not working correctly
+
+### Documented
+- Added missing `cleanup-history` command documentation
+- Added missing `simulate-consumption` command documentation
+- Removed confusing duplicate command sections
+- Added command options and usage examples throughout
+- Corrected all command schedules (hourly at :15/:30, every 10 minutes, etc.)
+
+---
+
+## Version 1.0.9 — *November 2025*
 
 ### 🐛 Bug Fixes
 

--- a/src/Console/Commands/CreateTestPoses.php
+++ b/src/Console/Commands/CreateTestPoses.php
@@ -1,0 +1,571 @@
+<?php
+
+namespace StructureManager\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+/**
+ * Create test POSes for development and testing
+ * 
+ * This command creates fake POSes in multiple corporations with fuel reserves
+ * for testing webhook filtering, notifications, and fuel consumption
+ * 
+ * Usage:
+ * php artisan structure-manager:create-test-poses
+ * php artisan structure-manager:create-test-poses --corporations=5 --poses-per-corp=3
+ * php artisan structure-manager:create-test-poses --fast-consumption
+ */
+class CreateTestPoses extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'structure-manager:create-test-poses
+                            {--corporations=3 : Number of test corporations to create (max 10)}
+                            {--poses-per-corp=2 : Number of POSes per corporation (max 10)}
+                            {--fast-consumption : Enable 20-minute consumption cycles for testing}
+                            {--cleanup : Remove all test data}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Create test POSes with fuel for testing webhooks and notifications (SAFE ranges: corps 2.1B+, POSes 2.2B+, far outside EVE allocation)';
+
+
+    /**
+     * POS tower type IDs and their properties
+     */
+    private $towerTypes = [
+        // Amarr Towers
+        12235 => ['name' => 'Amarr Control Tower', 'fuel_per_hour' => 40, 'strontium_capacity' => 50000],
+        16213 => ['name' => 'Amarr Control Tower Medium', 'fuel_per_hour' => 20, 'strontium_capacity' => 25000],
+        20059 => ['name' => 'Amarr Control Tower Small', 'fuel_per_hour' => 10, 'strontium_capacity' => 12500],
+        
+        // Caldari Towers
+        16214 => ['name' => 'Caldari Control Tower', 'fuel_per_hour' => 40, 'strontium_capacity' => 50000],
+        16217 => ['name' => 'Caldari Control Tower Medium', 'fuel_per_hour' => 20, 'strontium_capacity' => 25000],
+        20060 => ['name' => 'Caldari Control Tower Small', 'fuel_per_hour' => 10, 'strontium_capacity' => 12500],
+        
+        // Gallente Towers
+        12236 => ['name' => 'Gallente Control Tower', 'fuel_per_hour' => 40, 'strontium_capacity' => 50000],
+        16221 => ['name' => 'Gallente Control Tower Medium', 'fuel_per_hour' => 20, 'strontium_capacity' => 25000],
+        20061 => ['name' => 'Gallente Control Tower Small', 'fuel_per_hour' => 10, 'strontium_capacity' => 12500],
+        
+        // Minmatar Towers
+        16216 => ['name' => 'Minmatar Control Tower', 'fuel_per_hour' => 40, 'strontium_capacity' => 50000],
+        16220 => ['name' => 'Minmatar Control Tower Medium', 'fuel_per_hour' => 20, 'strontium_capacity' => 25000],
+        20062 => ['name' => 'Minmatar Control Tower Small', 'fuel_per_hour' => 10, 'strontium_capacity' => 12500],
+    ];
+
+    /**
+     * Test corporation names
+     */
+    private $corpNames = [
+        'Test Corporation Alpha',
+        'Test Corporation Beta',
+        'Test Corporation Gamma',
+        'Test Corporation Delta',
+        'Test Corporation Epsilon',
+        'Test Corporation Zeta',
+        'Test Corporation Eta',
+        'Test Corporation Theta',
+    ];
+
+    /**
+     * Test solar system IDs (various security levels)
+     */
+    private $testSystems = [
+        // High-sec
+        30000142 => ['name' => 'Jita', 'security' => 0.9, 'requires_charters' => true],
+        30002187 => ['name' => 'Amarr', 'security' => 1.0, 'requires_charters' => true],
+        
+        // Low-sec
+        30002053 => ['name' => 'Amamake', 'security' => 0.4, 'requires_charters' => false],
+        30002187 => ['name' => 'Tama', 'security' => 0.3, 'requires_charters' => false],
+        
+        // Null-sec (using some random IDs for testing)
+        30004970 => ['name' => 'Test Null System 1', 'security' => -0.5, 'requires_charters' => false],
+        30004971 => ['name' => 'Test Null System 2', 'security' => -0.8, 'requires_charters' => false],
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if ($this->option('cleanup')) {
+            return $this->cleanup();
+        }
+
+        $corpCount = (int) $this->option('corporations');
+        $posesPerCorp = (int) $this->option('poses-per-corp');
+        $fastConsumption = $this->option('fast-consumption');
+        
+        // Enforce safety limits
+        $maxCorps = 10;
+        $maxPosesPerCorp = 10;
+        
+        if ($corpCount > $maxCorps) {
+            $this->warn("Limiting corporations to {$maxCorps} (safety limit to avoid real EVE corp IDs)");
+            $corpCount = $maxCorps;
+        }
+        
+        if ($posesPerCorp > $maxPosesPerCorp) {
+            $this->warn("Limiting POSes per corp to {$maxPosesPerCorp} (safety limit)");
+            $posesPerCorp = $maxPosesPerCorp;
+        }
+
+        $this->info("Creating test data...");
+        $this->info("Corporations: {$corpCount}");
+        $this->info("POSes per corp: {$posesPerCorp}");
+        $this->info("Fast consumption: " . ($fastConsumption ? 'YES (20-min cycles)' : 'NO (normal hourly)'));
+        $this->newLine();
+        
+        $this->info("ℹ️  SAFE ID ranges (far outside EVE's normal allocation):");
+        $this->info("  Corporations: 2100000000-2100000099 (2.1 billion range)");
+        $this->info("  POSes: 2200000000-2200000999 (2.2 billion range)");
+        $this->info("  Assets: 22000000000+ (based on POS IDs)");
+        $this->line("  ✅ These ranges do NOT overlap with any real EVE data");
+        $this->newLine();
+
+        // Create test corporations (no character linking due to PRIMARY KEY constraint)
+        $corporations = $this->createTestCorporations($corpCount, null);
+        
+        $totalPoses = 0;
+        foreach ($corporations as $corp) {
+            $this->info("Creating POSes for {$corp['name']} (ID: {$corp['corporation_id']})...");
+            
+            $poses = $this->createTestPosesForCorp($corp, $posesPerCorp, $fastConsumption);
+            $totalPoses += count($poses);
+            
+            foreach ($poses as $pos) {
+                $this->line("  ✓ {$pos['name']} - Fuel: {$pos['fuel_days']}d, Strontium: {$pos['strontium_hours']}h");
+            }
+            $this->newLine();
+        }
+
+        $this->info("✓ Created {$totalPoses} test POSes in {$corpCount} corporations");
+        
+        if ($fastConsumption) {
+            $this->warn("⚡ Fast consumption enabled - fuel will be consumed every 20 minutes");
+            $this->info("Run the fuel tracking job to see consumption:");
+            $this->line("  php artisan structure-manager:track-poses-fuel");
+        }
+        
+        $this->newLine();
+        $this->info("Test webhooks with these corporations to verify filtering!");
+        $this->info("To remove test data, run: php artisan structure-manager:create-test-poses --cleanup");
+    }
+    
+    /**
+     * Get character ID for linking test corporations
+     * 
+     * @return int|null
+     */
+
+    /**
+     * Create test corporations
+     */
+    private function createTestCorporations($count, $characterId = null)
+    {
+        $corporations = [];
+        // Use 2.1 billion range - FAR outside EVE's normal corp ID allocation
+        // Real EVE corps are in 98million-99million range
+        $baseCorpId = 2100000000; // 2.1 billion - safe from real corps
+        $maxTestCorps = 100; // Maximum test corporations
+        
+        // Safety check
+        if ($count > $maxTestCorps) {
+            $this->error("Cannot create more than {$maxTestCorps} test corporations (safety limit)");
+            $count = $maxTestCorps;
+        }
+        
+        for ($i = 0; $i < $count; $i++) {
+            $corpId = $baseCorpId + $i;
+            $corpName = $this->corpNames[$i % count($this->corpNames)] . " #{$i}";
+            
+            // Check if corporation already exists in corporation_infos
+            $existingCorp = DB::table('corporation_infos')
+                ->where('corporation_id', $corpId)
+                ->first();
+            
+            if (!$existingCorp) {
+                DB::table('corporation_infos')->insert([
+                    'corporation_id' => $corpId,
+                    'name' => $corpName,
+                    'ticker' => 'TST' . $i,
+                    'member_count' => rand(10, 100),
+                    'ceo_id' => 1,
+                    'creator_id' => 1, // Required field
+                    'alliance_id' => null,
+                    'description' => 'Test corporation for webhook and notification testing',
+                    'tax_rate' => 0.1,
+                    'url' => 'https://test.corp',
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
+                
+                // Note: character_affiliations uses character_id as PRIMARY KEY
+                // Each character can only belong to ONE corporation
+                // We cannot link multiple test corporations without breaking the user's real affiliation
+                // So we skip this and rely on admin permissions instead
+                
+                if ($characterId && $i == 0) {
+                    // Only show this message once
+                    $this->newLine();
+                    $this->warn("⚠️  Note: Due to SeAT's permission model, we cannot link test corporations to your character.");
+                    $this->warn("Each character can only belong to ONE corporation in character_affiliations.");
+                    $this->newLine();
+                    $this->info("Test corporations will be created but may not be visible in some UI pages.");
+                    $this->info("If you have admin/superuser access, you may still be able to see them.");
+                    $this->newLine();
+                }
+            }
+            
+            $corporations[] = [
+                'corporation_id' => $corpId,
+                'name' => $corpName,
+            ];
+        }
+        
+        return $corporations;
+    }
+
+    /**
+     * Create test POSes for a corporation
+     */
+    private function createTestPosesForCorp($corp, $count, $fastConsumption)
+    {
+        $poses = [];
+        // Use 2.2 billion range - FAR outside EVE's normal starbase ID allocation
+        // Calculate offset based on corporation's position (0-99)
+        $corpOffset = ($corp['corporation_id'] - 2100000000) * 10; // Each corp gets 10 POS IDs  
+        $baseStarbaseId = 2200000000 + $corpOffset; // 2.2 billion base
+        
+        // Safety check - don't exceed our safe POS ID range
+        if ($baseStarbaseId + $count > 2200001000) {
+            $this->error("POS ID range exceeded! Reduce corporations or POSes per corp.");
+            return [];
+        }
+        
+        $towerTypeIds = array_keys($this->towerTypes);
+        $systemIds = array_keys($this->testSystems);
+        
+        for ($i = 0; $i < $count; $i++) {
+            $starbaseId = $baseStarbaseId + $i;
+            $towerTypeId = $towerTypeIds[array_rand($towerTypeIds)];
+            $towerInfo = $this->towerTypes[$towerTypeId];
+            $systemId = $systemIds[array_rand($systemIds)];
+            $systemInfo = $this->testSystems[$systemId];
+            
+            // Random fuel levels for variety
+            $fuelScenarios = [
+                ['days' => 30, 'strontium' => 72], // Good
+                ['days' => 10, 'strontium' => 8], // Warning
+                ['days' => 5, 'strontium' => 4], // Critical
+                ['days' => 1, 'strontium' => 0], // Very critical / Zero strontium
+                ['days' => 15, 'strontium' => 48], // Normal
+            ];
+            
+            $scenario = $fuelScenarios[$i % count($fuelScenarios)];
+            
+            // Calculate quantities
+            $fuelPerHour = $fastConsumption ? $towerInfo['fuel_per_hour'] * 3 : $towerInfo['fuel_per_hour'];
+            $fuelQuantity = (int) ($scenario['days'] * 24 * $fuelPerHour);
+            $strontiumQuantity = (int) ($scenario['strontium'] * 200); // ~200 per hour consumption
+            
+            $posName = "{$towerInfo['name']} - Test {$i}";
+            
+            // Create in corporation_starbases
+            DB::table('corporation_starbases')->updateOrInsert(
+                [
+                    'starbase_id' => $starbaseId,
+                    'corporation_id' => $corp['corporation_id']
+                ],
+                [
+                    'moon_id' => null,
+                    'system_id' => $systemId,
+                    'type_id' => $towerTypeId,
+                    'state' => 'online', // ENUM: 'offline','online','onlining','reinforced','unanchoring'
+                    'onlined_since' => Carbon::now()->subDays(30),
+                    'reinforced_until' => null,
+                    'unanchor_at' => null,
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]
+            );
+            
+            // Create fuel history
+            $metadata = [
+                'system_name' => $systemInfo['name'],
+                'tower_type' => $towerInfo['name'],
+                'fuel_per_hour' => $fuelPerHour,
+            ];
+            
+            DB::table('starbase_fuel_history')->insert([
+                'starbase_id' => $starbaseId,
+                'corporation_id' => $corp['corporation_id'],
+                'tower_type_id' => $towerTypeId,
+                'starbase_name' => $posName,
+                'system_id' => $systemId,
+                'state' => 4, // Online
+                'fuel_blocks_quantity' => $fuelQuantity,
+                'fuel_days_remaining' => $scenario['days'],
+                'fuel_blocks_used' => 0,
+                'fuel_hourly_consumption' => $fuelPerHour,
+                'strontium_quantity' => $strontiumQuantity,
+                'strontium_hours_available' => $scenario['strontium'],
+                'strontium_status' => $scenario['strontium'] < 6 ? 'critical' : ($scenario['strontium'] < 12 ? 'warning' : 'good'),
+                'charter_quantity' => $systemInfo['requires_charters'] ? 1000 : null,
+                'charter_days_remaining' => $systemInfo['requires_charters'] ? 30 : null,
+                'requires_charters' => $systemInfo['requires_charters'],
+                'actual_days_remaining' => $scenario['days'],
+                'limiting_factor' => 'fuel',
+                'estimated_fuel_expiry' => Carbon::now()->addDays($scenario['days']),
+                'system_security' => $systemInfo['security'],
+                'space_type' => $systemInfo['security'] >= 0.5 ? 'High-Sec' : ($systemInfo['security'] > 0 ? 'Low-Sec' : 'Null-Sec'),
+                'metadata' => json_encode($metadata),
+                'last_fuel_notification_status' => null,
+                'last_fuel_notification_at' => null,
+                'fuel_final_alert_sent' => false,
+                'last_strontium_notification_status' => null,
+                'last_strontium_notification_at' => null,
+                'strontium_final_alert_sent' => false,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+            
+            // Add fuel to corporation hangar (for consumption tracking)
+            $hangarDivision = rand(1, 7); // Random hangar
+            
+            // Fuel blocks (type 4051)
+            DB::table('corporation_assets')->insert([
+                'corporation_id' => $corp['corporation_id'],
+                'item_id' => $starbaseId * 10 + 1, // Unique item ID
+                'type_id' => 4051, // Fuel Block type
+                'quantity' => $fuelQuantity + 10000, // Extra fuel for consumption
+                'location_id' => $systemId,
+                'location_type' => 'station',
+                'location_flag' => 'CorpSAG' . $hangarDivision,
+                'is_singleton' => false,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+            
+            // Strontium Clathrates (type 16275)
+            if ($strontiumQuantity > 0 || rand(0, 1)) { // Add strontium even if POS has 0 (in hangar)
+                DB::table('corporation_assets')->insert([
+                    'corporation_id' => $corp['corporation_id'],
+                    'item_id' => $starbaseId * 10 + 2, // Unique item ID
+                    'type_id' => 16275, // Strontium Clathrates
+                    'quantity' => max($strontiumQuantity, 5000), // At least some strontium
+                    'location_id' => $systemId,
+                    'location_type' => 'station',
+                    'location_flag' => 'CorpSAG' . $hangarDivision,
+                    'is_singleton' => false,
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
+            }
+            
+            // Add charters if high-sec
+            if ($systemInfo['requires_charters']) {
+                DB::table('corporation_assets')->insert([
+                    'corporation_id' => $corp['corporation_id'],
+                    'item_id' => $starbaseId * 10 + 3, // Unique item ID
+                    'type_id' => 24592, // Sovereignty Charter (high-sec)
+                    'quantity' => 2000,
+                    'location_id' => $systemId,
+                    'location_type' => 'station',
+                    'location_flag' => 'CorpSAG' . $hangarDivision,
+                    'is_singleton' => false,
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
+            }
+            
+            $poses[] = [
+                'starbase_id' => $starbaseId,
+                'name' => $posName,
+                'fuel_days' => $scenario['days'],
+                'strontium_hours' => $scenario['strontium'],
+                'system' => $systemInfo['name'],
+            ];
+        }
+        
+        return $poses;
+    }
+
+    /**
+     * Cleanup test data
+     */
+    private function cleanup()
+    {
+        $this->warn("⚠️  CLEANUP MODE - Removing test data");
+        $this->newLine();
+        
+        // Define CURRENT SAFE test ID ranges (2.1-2.3 billion - outside EVE's normal allocation)
+        $testCorpMin = 2100000000;
+        $testCorpMax = 2100000099;  // 100 test corp IDs
+        $testPosMin = 2200000000;
+        $testPosMax = 2200000999;   // 1000 test POS IDs (100 corps * 10 POSes)
+        $testAssetMin = 22000000000;
+        $testAssetMax = 22000009999; // Asset IDs based on POS IDs
+        
+        // Define LEGACY test ID ranges (from older versions - will also be cleaned)
+        $legacyRanges = [
+            // Very old range (99 billion)
+            ['type' => 'pos', 'min' => 99000000000, 'max' => 99999999999],
+            // Old range (1 billion)
+            ['type' => 'pos', 'min' => 1000000000, 'max' => 1000000099],
+            ['type' => 'asset', 'min' => 10000000000, 'max' => 10000000099],
+            // Unsafe corp range (DO NOT USE FOR NEW DATA!)
+            ['type' => 'corp', 'min' => 98000000, 'max' => 98000099],
+        ];
+        
+        // Check current test data
+        $corpsToDelete = DB::table('corporation_infos')
+            ->whereBetween('corporation_id', [$testCorpMin, $testCorpMax])
+            ->get();
+        
+        $posesToDelete = DB::table('corporation_starbases')
+            ->whereBetween('starbase_id', [$testPosMin, $testPosMax])
+            ->count();
+        
+        // Check for legacy data
+        $legacyPoses = 0;
+        $legacyCorps = collect();
+        
+        foreach ($legacyRanges as $range) {
+            if ($range['type'] === 'pos') {
+                $legacyPoses += DB::table('corporation_starbases')
+                    ->whereBetween('starbase_id', [$range['min'], $range['max']])
+                    ->count();
+            } elseif ($range['type'] === 'corp') {
+                $found = DB::table('corporation_infos')
+                    ->whereBetween('corporation_id', [$range['min'], $range['max']])
+                    ->get();
+                $legacyCorps = $legacyCorps->merge($found);
+            }
+        }
+        
+        if ($corpsToDelete->isEmpty() && $posesToDelete == 0 && $legacyPoses == 0 && $legacyCorps->isEmpty()) {
+            $this->info("No test data found to clean up.");
+            return 0;
+        }
+        
+        $this->info("Found test data to remove:");
+        $this->newLine();
+        
+        if ($corpsToDelete->count() > 0) {
+            $this->line("  • {$corpsToDelete->count()} test corporations (IDs: {$testCorpMin}-{$testCorpMax})");
+            $this->table(
+                ['Corporation ID', 'Name'],
+                $corpsToDelete->map(fn($c) => [$c->corporation_id, $c->name])->toArray()
+            );
+        }
+        
+        if ($legacyCorps->count() > 0) {
+            $this->line("  • {$legacyCorps->count()} LEGACY test corporations (IDs: 98000000-98000099)");
+            $this->warn("    ⚠️  These are from an older UNSAFE version of the test command");
+            $this->table(
+                ['Corporation ID', 'Name'],
+                $legacyCorps->map(fn($c) => [$c->corporation_id, $c->name])->toArray()
+            );
+        }
+        
+        if ($posesToDelete > 0) {
+            $this->line("  • {$posesToDelete} test POSes (IDs: {$testPosMin}-{$testPosMax})");
+        }
+        
+        if ($legacyPoses > 0) {
+            $this->line("  • {$legacyPoses} LEGACY test POSes (various old ID ranges)");
+            $this->warn("    ⚠️  These are from older versions of the test command");
+        }
+        
+        $this->line("  • Related fuel history and assets");
+        $this->newLine();
+        
+        // Confirm deletion
+        if (!$this->confirm('⚠️  Delete this test data?', false)) {
+            $this->info("Cleanup cancelled.");
+            return 0;
+        }
+        
+        $this->newLine();
+        $this->info("Deleting test data...");
+        
+        // Delete CURRENT test data
+        $deletedCorps = DB::table('corporation_infos')
+            ->whereBetween('corporation_id', [$testCorpMin, $testCorpMax])
+            ->delete();
+        
+        $deletedPoses = DB::table('corporation_starbases')
+            ->whereBetween('starbase_id', [$testPosMin, $testPosMax])
+            ->delete();
+        
+        $deletedFuel = DB::table('starbase_fuel_history')
+            ->whereBetween('starbase_id', [$testPosMin, $testPosMax])
+            ->delete();
+        
+        $deletedAssets = DB::table('corporation_assets')
+            ->whereBetween('item_id', [$testAssetMin, $testAssetMax])
+            ->delete();
+        
+        // Delete LEGACY test data from all old ranges
+        $deletedLegacyCorps = 0;
+        $deletedLegacyPoses = 0;
+        $deletedLegacyFuel = 0;
+        $deletedLegacyAssets = 0;
+        
+        foreach ($legacyRanges as $range) {
+            if ($range['type'] === 'corp') {
+                $deletedLegacyCorps += DB::table('corporation_infos')
+                    ->whereBetween('corporation_id', [$range['min'], $range['max']])
+                    ->delete();
+            } elseif ($range['type'] === 'pos') {
+                $deletedLegacyPoses += DB::table('corporation_starbases')
+                    ->whereBetween('starbase_id', [$range['min'], $range['max']])
+                    ->delete();
+                $deletedLegacyFuel += DB::table('starbase_fuel_history')
+                    ->whereBetween('starbase_id', [$range['min'], $range['max']])
+                    ->delete();
+                // Assets using starbase_id as location_id
+                $deletedLegacyAssets += DB::table('corporation_assets')
+                    ->whereBetween('location_id', [$range['min'], $range['max']])
+                    ->delete();
+            } elseif ($range['type'] === 'asset') {
+                $deletedLegacyAssets += DB::table('corporation_assets')
+                    ->whereBetween('item_id', [$range['min'], $range['max']])
+                    ->delete();
+            }
+        }
+        
+        // Report results
+        $this->newLine();
+        if ($deletedCorps > 0) {
+            $this->info("✓ Deleted {$deletedCorps} test corporations (2.1 billion range)");
+        }
+        if ($deletedLegacyCorps > 0) {
+            $this->info("✓ Deleted {$deletedLegacyCorps} LEGACY test corporations (old ranges)");
+        }
+        if ($deletedPoses > 0) {
+            $this->info("✓ Deleted {$deletedPoses} test POSes (2.2 billion range)");
+        }
+        if ($deletedLegacyPoses > 0) {
+            $this->info("✓ Deleted {$deletedLegacyPoses} LEGACY test POSes (old ranges)");
+        }
+        if ($deletedFuel > 0 || $deletedLegacyFuel > 0) {
+            $this->info("✓ Deleted " . ($deletedFuel + $deletedLegacyFuel) . " fuel history records");
+        }
+        if ($deletedAssets > 0 || $deletedLegacyAssets > 0) {
+            $this->info("✓ Deleted " . ($deletedAssets + $deletedLegacyAssets) . " test assets");
+        }
+        $this->newLine();
+        $this->info("Cleanup complete!");
+        
+        return 0;
+    }
+}

--- a/src/Console/Commands/SimulateFastConsumption.php
+++ b/src/Console/Commands/SimulateFastConsumption.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace StructureManager\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+/**
+ * Simulate fast fuel consumption for testing
+ * 
+ * This command simulates 20-minute consumption cycles instead of hourly
+ * Run it manually or schedule it every 20 minutes during testing
+ * 
+ * Usage:
+ * php artisan structure-manager:simulate-consumption
+ * php artisan structure-manager:simulate-consumption --cycles=3
+ */
+class SimulateFastConsumption extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'structure-manager:simulate-consumption
+                            {--cycles=1 : Number of 20-minute cycles to simulate}
+                            {--test-only : Only process test POSes (IDs >= 1000000000)}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Simulate fast fuel consumption for testing (20-minute cycles)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $cycles = (int) $this->option('cycles');
+        $testOnly = $this->option('test-only');
+        
+        $this->info("Simulating {$cycles} consumption cycle(s) at 20-minute intervals...");
+        if ($testOnly) {
+            $this->info("Processing TEST POSes only (IDs >= 1000000000)");
+        }
+        $this->newLine();
+
+        for ($i = 1; $i <= $cycles; $i++) {
+            $this->info("Cycle {$i}/{$cycles}:");
+            $this->processCycle($testOnly);
+            $this->newLine();
+            
+            if ($i < $cycles) {
+                $this->line("Waiting 1 second before next cycle...");
+                sleep(1);
+            }
+        }
+
+        $this->info("✓ Simulation complete!");
+        $this->info("Check notifications and fuel levels");
+    }
+
+    /**
+     * Process one consumption cycle
+     */
+    private function processCycle($testOnly)
+    {
+        // Get all online POSes
+        $query = DB::table('starbase_fuel_history as sfh')
+            ->select('sfh.*')
+            ->whereIn('sfh.id', function($subquery) {
+                $subquery->select(DB::raw('MAX(id)'))
+                    ->from('starbase_fuel_history')
+                    ->groupBy('starbase_id');
+            })
+            ->where('sfh.state', 4); // Online only
+        
+        if ($testOnly) {
+            $query->where('sfh.starbase_id', '>=', 1000000000);
+        }
+        
+        $poses = $query->get();
+        
+        if ($poses->isEmpty()) {
+            $this->warn("No online POSes found");
+            return;
+        }
+
+        $this->line("Processing {$poses->count()} online POS(es)...");
+        
+        $consumedCount = 0;
+        $lowFuelCount = 0;
+        $criticalCount = 0;
+        
+        foreach ($poses as $pos) {
+            $result = $this->consumeFuel($pos);
+            
+            if ($result['consumed']) {
+                $consumedCount++;
+            }
+            
+            if ($result['status'] === 'low') {
+                $lowFuelCount++;
+                $this->line("  ⚠️  {$pos->starbase_name}: {$result['fuel_remaining']}d fuel remaining");
+            } elseif ($result['status'] === 'critical') {
+                $criticalCount++;
+                $this->warn("  🔴 {$pos->starbase_name}: {$result['fuel_remaining']}d fuel remaining (CRITICAL!)");
+            }
+            
+            // Check strontium
+            if ($result['strontium_hours'] < 6) {
+                $this->warn("  🛡️  {$pos->starbase_name}: {$result['strontium_hours']}h strontium (CRITICAL!)");
+            }
+        }
+        
+        $this->info("  ✓ Consumed fuel for {$consumedCount} POS(es)");
+        if ($lowFuelCount > 0) {
+            $this->warn("  ⚠️  {$lowFuelCount} POS(es) with low fuel");
+        }
+        if ($criticalCount > 0) {
+            $this->error("  🔴 {$criticalCount} POS(es) with critical fuel!");
+        }
+    }
+
+    /**
+     * Consume fuel for a POS (20-minute cycle)
+     */
+    private function consumeFuel($pos)
+    {
+        $metadata = json_decode($pos->metadata, true) ?? [];
+        $fuelPerHour = $metadata['fuel_per_hour'] ?? 40;
+        
+        // Calculate 20-minute consumption (1/3 of hourly rate)
+        $fuelConsumed = $fuelPerHour / 3;
+        $strontiumConsumed = 0; // Strontium only consumed when reinforced
+        
+        // Consume fuel blocks
+        $newFuelQuantity = max(0, $pos->fuel_blocks_quantity - $fuelConsumed);
+        $newFuelDays = $newFuelQuantity / ($fuelPerHour * 24);
+        
+        // Calculate new values
+        $newStrontiumHours = $pos->strontium_hours_available; // Unchanged for online POS
+        
+        // Determine status
+        $status = 'good';
+        if ($newFuelDays < 7) {
+            $status = 'critical';
+        } elseif ($newFuelDays < 14) {
+            $status = 'low';
+        }
+        
+        // Update fuel history
+        DB::table('starbase_fuel_history')->insert([
+            'starbase_id' => $pos->starbase_id,
+            'corporation_id' => $pos->corporation_id,
+            'tower_type_id' => $pos->tower_type_id,
+            'starbase_name' => $pos->starbase_name,
+            'system_id' => $pos->system_id,
+            'state' => $pos->state,
+            'fuel_blocks_quantity' => $newFuelQuantity,
+            'fuel_days_remaining' => $newFuelDays,
+            'fuel_blocks_used' => $fuelConsumed,
+            'fuel_hourly_consumption' => $fuelPerHour,
+            'strontium_quantity' => $pos->strontium_quantity,
+            'strontium_hours_available' => $newStrontiumHours,
+            'strontium_status' => $pos->strontium_status,
+            'charter_quantity' => $pos->charter_quantity,
+            'charter_days_remaining' => $pos->charter_days_remaining,
+            'requires_charters' => $pos->requires_charters,
+            'actual_days_remaining' => $newFuelDays,
+            'limiting_factor' => $pos->limiting_factor,
+            'estimated_fuel_expiry' => Carbon::now()->addDays($newFuelDays),
+            'system_security' => $pos->system_security,
+            'space_type' => $pos->space_type,
+            'metadata' => $pos->metadata,
+            'last_fuel_notification_status' => $pos->last_fuel_notification_status,
+            'last_fuel_notification_at' => $pos->last_fuel_notification_at,
+            'fuel_final_alert_sent' => $pos->fuel_final_alert_sent,
+            'last_strontium_notification_status' => $pos->last_strontium_notification_status,
+            'last_strontium_notification_at' => $pos->last_strontium_notification_at,
+            'strontium_final_alert_sent' => $pos->strontium_final_alert_sent,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+        
+        return [
+            'consumed' => $fuelConsumed > 0,
+            'fuel_remaining' => round($newFuelDays, 1),
+            'strontium_hours' => $newStrontiumHours,
+            'status' => $status,
+        ];
+    }
+}

--- a/src/Database/migrations/2025_10_01_000016_add_multiple_webhook_support.php
+++ b/src/Database/migrations/2025_10_01_000016_add_multiple_webhook_support.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add support for multiple webhooks with corporation filtering
+ * 
+ * This migration:
+ * 1. Creates a new table for webhook configurations
+ * 2. Migrates existing single webhook to the new table
+ * 3. Adds corporation_id filtering support
+ */
+class AddMultipleWebhookSupport extends Migration
+{
+    public function up()
+    {
+        // Create new webhooks table
+        Schema::create('structure_manager_webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('webhook_url', 500)->comment('Discord/Slack webhook URL');
+            $table->bigInteger('corporation_id')->nullable()->comment('Corporation ID filter (null = all corporations)');
+            $table->boolean('enabled')->default(true)->comment('Whether this webhook is active');
+            $table->string('description', 255)->nullable()->comment('Optional description/label for this webhook');
+            $table->timestamps();
+            
+            $table->index('corporation_id');
+            $table->index('enabled');
+        });
+        
+        // Migrate existing webhook to new table if it exists
+        $existingWebhook = DB::table('structure_manager_settings')
+            ->where('key', 'pos_webhook_url')
+            ->first();
+            
+        $webhookEnabled = DB::table('structure_manager_settings')
+            ->where('key', 'pos_webhook_enabled')
+            ->first();
+        
+        if ($existingWebhook && $existingWebhook->value) {
+            DB::table('structure_manager_webhooks')->insert([
+                'webhook_url' => $existingWebhook->value,
+                'corporation_id' => null, // Null = all corporations (preserve existing behavior)
+                'enabled' => $webhookEnabled ? (bool)$webhookEnabled->value : true,
+                'description' => 'Migrated from legacy webhook',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+        
+        // Add new settings for strontium notification behavior
+        $settings = [
+            [
+                'key' => 'pos_strontium_zero_notify_once',
+                'value' => '1',
+                'type' => 'boolean',
+                'category' => 'notifications',
+                'description' => 'For online POSes with 0 strontium, only notify once instead of on interval'
+            ],
+            [
+                'key' => 'pos_strontium_zero_grace_period',
+                'value' => '2',
+                'type' => 'integer',
+                'category' => 'notifications',
+                'description' => 'Grace period in hours before considering 0 strontium as "accepted risk" (default: 2h)'
+            ],
+        ];
+        
+        foreach ($settings as $setting) {
+            DB::table('structure_manager_settings')->insertOrIgnore($setting);
+        }
+    }
+
+    public function down()
+    {
+        // Migrate first webhook back to settings if exists
+        $firstWebhook = DB::table('structure_manager_webhooks')
+            ->where('enabled', true)
+            ->first();
+            
+        if ($firstWebhook) {
+            DB::table('structure_manager_settings')
+                ->where('key', 'pos_webhook_url')
+                ->update(['value' => $firstWebhook->webhook_url]);
+                
+            DB::table('structure_manager_settings')
+                ->where('key', 'pos_webhook_enabled')
+                ->update(['value' => '1']);
+        }
+        
+        // Drop the webhooks table
+        Schema::dropIfExists('structure_manager_webhooks');
+        
+        // Remove new settings
+        DB::table('structure_manager_settings')
+            ->whereIn('key', [
+                'pos_strontium_zero_notify_once',
+                'pos_strontium_zero_grace_period'
+            ])
+            ->delete();
+    }
+}

--- a/src/Database/migrations/2025_10_01_000017_add_role_mention_to_webhooks.php
+++ b/src/Database/migrations/2025_10_01_000017_add_role_mention_to_webhooks.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add role_mention column to structure_manager_webhooks table
+ * 
+ * This allows each webhook to have its own Discord role mention,
+ * enabling different role pings for different corporations/channels
+ */
+class AddRoleMentionToWebhooks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('structure_manager_webhooks', function (Blueprint $table) {
+            $table->string('role_mention', 100)->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('structure_manager_webhooks', function (Blueprint $table) {
+            $table->dropColumn('role_mention');
+        });
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -156,7 +156,7 @@ Route::group([
         'middleware' => 'can:structure-manager.admin',
     ]);
     
-    // Test Webhook
+    // Test Webhook (legacy route - supports both old single webhook and new specific webhook testing)
     Route::post('/settings/test-webhook', [
         'as' => 'structure-manager.settings.test-webhook',
         'uses' => 'SettingsController@testWebhook',
@@ -167,6 +167,45 @@ Route::group([
     Route::get('/settings/reset', [
         'as' => 'structure-manager.settings.reset',
         'uses' => 'SettingsController@reset',
+        'middleware' => 'can:structure-manager.admin',
+    ]);
+    
+    // ============================================
+    // Webhook Management (NEW)
+    // ============================================
+    
+    // Add Webhook
+    Route::post('/webhook/add', [
+        'as' => 'structure-manager.webhook.add',
+        'uses' => 'SettingsController@addWebhook',
+        'middleware' => 'can:structure-manager.admin',
+    ]);
+    
+    // Get Webhook (for editing)
+    Route::get('/webhook/{id}', [
+        'as' => 'structure-manager.webhook.get',
+        'uses' => 'SettingsController@getWebhook',
+        'middleware' => 'can:structure-manager.admin',
+    ]);
+    
+    // Update Webhook
+    Route::put('/webhook/{id}', [
+        'as' => 'structure-manager.webhook.update',
+        'uses' => 'SettingsController@updateWebhook',
+        'middleware' => 'can:structure-manager.admin',
+    ]);
+    
+    // Delete Webhook
+    Route::delete('/webhook/{id}', [
+        'as' => 'structure-manager.webhook.delete',
+        'uses' => 'SettingsController@deleteWebhook',
+        'middleware' => 'can:structure-manager.admin',
+    ]);
+    
+    // Test Specific Webhook
+    Route::post('/webhook/{id}/test', [
+        'as' => 'structure-manager.webhook.test',
+        'uses' => 'SettingsController@testWebhook',
         'middleware' => 'can:structure-manager.admin',
     ]);
     

--- a/src/Models/WebhookConfiguration.php
+++ b/src/Models/WebhookConfiguration.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace StructureManager\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model for webhook configurations
+ * 
+ * Allows multiple webhooks with corporation filtering
+ */
+class WebhookConfiguration extends Model
+{
+    protected $table = 'structure_manager_webhooks';
+    
+    protected $fillable = [
+        'webhook_url',
+        'corporation_id',
+        'enabled',
+        'description',
+        'role_mention',
+    ];
+    
+    protected $casts = [
+        'corporation_id' => 'integer',
+        'enabled' => 'boolean',
+    ];
+    
+    /**
+     * Get all enabled webhooks
+     * 
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public static function getEnabled()
+    {
+        return self::where('enabled', true)->get();
+    }
+    
+    /**
+     * Get webhooks for a specific corporation
+     * Includes both corporation-specific webhooks and "all corporations" webhooks
+     * 
+     * @param int $corporationId Corporation ID
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public static function getForCorporation($corporationId)
+    {
+        return self::where('enabled', true)
+            ->where(function($query) use ($corporationId) {
+                $query->whereNull('corporation_id') // All corporations
+                      ->orWhere('corporation_id', $corporationId); // Specific corporation
+            })
+            ->get();
+    }
+    
+    /**
+     * Get display label for corporation filter
+     * 
+     * @return string
+     */
+    public function getCorporationLabel()
+    {
+        if ($this->corporation_id === null) {
+            return 'All Corporations';
+        }
+        
+        // Try to get corporation name from SeAT
+        $corp = \DB::table('corporation_infos')
+            ->where('corporation_id', $this->corporation_id)
+            ->first();
+            
+        return $corp ? $corp->name : "Corporation #{$this->corporation_id}";
+    }
+    
+    /**
+     * Validate webhook URL format
+     * 
+     * @param string $url
+     * @return bool
+     */
+    public static function isValidWebhookUrl($url)
+    {
+        // Check if it's a valid URL
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+        
+        // Check if it's a Discord or Slack webhook
+        $parsed = parse_url($url);
+        $host = $parsed['host'] ?? '';
+        
+        return stripos($host, 'discord.com') !== false || 
+               stripos($host, 'slack.com') !== false ||
+               stripos($host, 'hooks.slack.com') !== false;
+    }
+}

--- a/src/StructureManagerServiceProvider.php
+++ b/src/StructureManagerServiceProvider.php
@@ -10,6 +10,8 @@ use StructureManager\Console\Commands\CreateTestMetenoxCommand;
 use StructureManager\Console\Commands\TrackPosesFuelCommand;
 use StructureManager\Console\Commands\AnalyzePosConsumptionCommand;
 use StructureManager\Console\Commands\NotifyPosFuelCommand;
+use StructureManager\Console\Commands\CreateTestPoses;
+use StructureManager\Console\Commands\SimulateFastConsumption;
 use StructureManager\Database\Seeders\ScheduleSeeder;
 
 class StructureManagerServiceProvider extends AbstractSeatPlugin
@@ -36,6 +38,8 @@ class StructureManagerServiceProvider extends AbstractSeatPlugin
                 TrackPosesFuelCommand::class,
                 AnalyzePosConsumptionCommand::class,
                 NotifyPosFuelCommand::class,
+                CreateTestPoses::class,
+                SimulateFastConsumption::class,
             ]);
         }
 

--- a/src/resources/lang/en/help.php
+++ b/src/resources/lang/en/help.php
@@ -404,10 +404,137 @@ return [
     'critical_example' => '<strong>Critical Alert Example:</strong><br><br>🚨 <strong>CRITICAL POS FUEL ALERT</strong><br><br><strong>Tower:</strong> Death Star (Large Amarr Control Tower)<br><strong>System:</strong> 3-FKCZ (Null-Sec)<br><strong>Corporation:</strong> Test Corp<br><br><strong>Fuel Blocks:</strong> 245 remaining (4.3 days) [LIMITING FACTOR]<br><strong>Strontium:</strong> 15,432 remaining<br><br><strong>Status:</strong> CRITICAL - Refuel immediately!',
     
     'warning_example' => '<strong>Warning Alert Example:</strong><br><br>⚠️ <strong>POS FUEL WARNING</strong><br><br><strong>Tower:</strong> Moon Mining Base (Medium Caldari Control Tower)<br><strong>System:</strong> J123456 (W-Space)<br><br><strong>Fuel Blocks:</strong> 5,840 remaining (12.2 days)<br><strong>Strontium:</strong> 8,200 remaining<br><br><strong>Status:</strong> LOW - Schedule refuel operation',
+
+    'zero_strontium_title' => 'Zero Strontium Behavior',
+    'zero_strontium_intro' => 'Structure Manager has intelligent handling for POSes with zero strontium clathrates, recognizing different scenarios and alerting appropriately.',
+    'zero_strontium_scenarios' => '<strong>Scenarios:</strong>
+        <ul>
+            <li><strong>Online POS (State 4) with 0 Strontium:</strong>
+                <ul>
+                    <li>Alert message: "Strontium Clathrates - Structure in Possible Danger"</li>
+                    <li>Severity: Warning level (yellow)</li>
+                    <li>Meaning: POS is operational but has no reinforcement protection</li>
+                    <li>Impact: If attacked, POS will enter reinforced mode without a timer</li>
+                    <li>Recommended action: Add strontium for defensive protection</li>
+                </ul>
+            </li>
+            <li><strong>Reinforced POS (State 3) with 0 Strontium:</strong>
+                <ul>
+                    <li>Alert message: "Strontium Clathrates - Structure in Danger!"</li>
+                    <li>Severity: Critical level (red)</li>
+                    <li>Meaning: POS is reinforced but has no timer protection</li>
+                    <li>Impact: POS can come out of reinforcement at any moment</li>
+                    <li>Recommended action: URGENT - Add strontium immediately</li>
+                </ul>
+            </li>
+        </ul>',
+    'zero_strontium_notification_behavior' => '<strong>Notification Behavior:</strong>
+        <ul>
+            <li><strong>One-time notification:</strong> Initial alert sent when 0 strontium is first detected</li>
+            <li><strong>Status change alerts:</strong> Additional notifications sent if POS state changes (online ↔ reinforced)</li>
+            <li><strong>No spam protection:</strong> Does not send repeated interval reminders for prolonged 0 strontium (configurable grace period: 2 hours)</li>
+            <li><strong>Grace period behavior:</strong> After initial notification, only sends new alerts if status changes or after grace period expires</li>
+            <li><strong>Final alert exemption:</strong> No "1 hour remaining" alert for strontium since it\'s already at 0</li>
+        </ul>',
+    'zero_strontium_use_cases' => '<strong>Common Use Cases:</strong>
+        <ul>
+            <li><strong>Economic POS:</strong> Low-value POSes in safe space where reinforcement protection isn\'t critical</li>
+            <li><strong>Planned decommission:</strong> POSes being shut down where defensive capabilities aren\'t needed</li>
+            <li><strong>High-sec only:</strong> POSes in very high security systems with minimal attack risk</li>
+            <li><strong>Emergency situations:</strong> When strontium supplies are depleted and immediate restocking isn\'t possible</li>
+        </ul>',
+
+    'multiple_webhooks_title' => 'Multiple Webhook Support',
+    'multiple_webhooks_intro' => 'Structure Manager supports up to 10 concurrent webhooks with per-webhook corporation filtering and role mentions. This is ideal for hosting multiple corporations with separate alert channels.',
+    'multiple_webhooks_features' => '<strong>Features:</strong>
+        <ul>
+            <li><strong>Up to 10 webhooks:</strong> Configure multiple Discord or Slack webhook URLs simultaneously</li>
+            <li><strong>Corporation filtering:</strong> Each webhook can target specific corporations or "all corporations"</li>
+            <li><strong>Independent configuration:</strong> Each webhook has its own enabled/disabled state</li>
+            <li><strong>Per-webhook role mentions:</strong> Different Discord role mentions for each webhook</li>
+            <li><strong>Optional descriptions:</strong> Add notes to identify webhook purpose</li>
+            <li><strong>Individual testing:</strong> Test each webhook separately to verify configuration</li>
+        </ul>',
+    'multiple_webhooks_use_cases' => '<strong>Use Cases:</strong>
+        <ul>
+            <li><strong>Multi-Corp Hosting:</strong> Main corporation uses Webhook #1, alt corporations #2-5 use separate webhooks
+                <ul>
+                    <li>Webhook #1 → Main Corp Discord (Corporation filter: "Main Corp" / Role: @Logistics-Main)</li>
+                    <li>Webhook #2 → Alt Corp 1 Discord (Corporation filter: "Alt Corp 1" / Role: @Logistics-Alt1)</li>
+                    <li>Webhook #3 → Alt Corp 2 Discord (Corporation filter: "Alt Corp 2" / Role: @Logistics-Alt2)</li>
+                    <li>Result: Each corporation receives only their POS alerts in their own channel</li>
+                </ul>
+            </li>
+            <li><strong>Alert Segregation:</strong> Separate channels for different alert types
+                <ul>
+                    <li>Webhook #1 → General POS alerts (All corps / Role: @Everyone)</li>
+                    <li>Webhook #2 → Critical-only channel (All corps / Role: @Directors)</li>
+                    <li>Configure different notification thresholds per channel</li>
+                </ul>
+            </li>
+            <li><strong>Regional Coordination:</strong> Multiple alliances sharing SeAT infrastructure
+                <ul>
+                    <li>Each alliance gets their own webhook targeting their corporations</li>
+                    <li>Alerts stay within alliance boundaries</li>
+                    <li>Different role mentions per alliance for appropriate escalation</li>
+                </ul>
+            </li>
+            <li><strong>Redundancy:</strong> Send critical alerts to multiple channels
+                <ul>
+                    <li>Webhook #1 → Primary ops channel</li>
+                    <li>Webhook #2 → Backup logistics channel</li>
+                    <li>Both configured for same corporations with different role mentions</li>
+                </ul>
+            </li>
+        </ul>',
+    'multiple_webhooks_configuration' => '<strong>Configuration:</strong>
+        <ol>
+            <li>Navigate to Settings → POS Notifications → Webhook Configuration</li>
+            <li>Click "Add Webhook" button (max 10 webhooks)</li>
+            <li>Enter webhook URL (Discord or Slack)</li>
+            <li>Select corporation filter:
+                <ul>
+                    <li>"All Corporations" - Receives alerts for all POSes regardless of corporation</li>
+                    <li>Specific Corporation - Receives alerts only for that corporation\'s POSes</li>
+                </ul>
+            </li>
+            <li>Configure Discord role mention (optional):
+                <ul>
+                    <li>Format: <code>&lt;@&amp;ROLE_ID&gt;</code> or just the role ID number</li>
+                    <li>Only triggers for critical and final alerts</li>
+                    <li>Leave empty for no mentions</li>
+                </ul>
+            </li>
+            <li>Add description (optional) to identify webhook purpose</li>
+            <li>Test webhook with "Test Webhook" button</li>
+            <li>Enable webhook to start receiving notifications</li>
+        </ol>',
+    'multiple_webhooks_example' => '<strong>Example Multi-Corp Setup:</strong><br>
+        <pre>Webhook #1:
+  URL: https://discord.com/api/webhooks/.../primary-corp
+  Corporation: Main Corp Alliance
+  Role Mention: &lt;@&amp;123456789&gt; (@Fuel-Team-Main)
+  Description: Main corp fuel alerts
+  Status: ✅ Enabled
+
+Webhook #2:
+  URL: https://discord.com/api/webhooks/.../alt-corp-1
+  Corporation: Alt Corp Alpha
+  Role Mention: &lt;@&amp;987654321&gt; (@Fuel-Team-Alpha)
+  Description: Alpha alt corp alerts
+  Status: ✅ Enabled
+
+Webhook #3:
+  URL: https://discord.com/api/webhooks/.../alt-corp-2
+  Corporation: Alt Corp Beta
+  Role Mention: &lt;@&amp;111222333&gt; (@Fuel-Team-Beta)
+  Description: Beta alt corp alerts
+  Status: ✅ Enabled</pre>',
     
     // Settings Section
     'settings_title' => 'Settings & Configuration',
     'settings_intro' => 'Configure Structure Manager to match your corporation\'s needs. Access settings from the main navigation menu.',
+    'settings_notification_note' => '<strong>Note:</strong> For detailed information about the notification system, webhook behavior, zero strontium alerts, and multiple webhook support, see the <a href="#notifications">Notifications section</a>.',
     
     'webhook_settings' => 'Webhook Settings',
     'webhook_settings_desc' => 'Configure Discord or Slack webhook notifications for POS fuel alerts.',
@@ -551,20 +678,56 @@ return [
     // Commands
     'commands_title' => 'Artisan Commands Reference',
     'commands_intro' => 'Structure Manager provides several artisan commands for manual operations and maintenance.',
+    'commands_notification_note' => '<strong>Note:</strong> For detailed information about the notification system, webhook configuration, and alert behavior, see the <a href="#notifications">Notifications section</a>.',
 
-    'track_fuel_cmd_title' => 'Track Fuel Levels',
-    'track_fuel_cmd_desc' => 'Manually triggers fuel level tracking for all Upwell structures. This reads fuel bay data from SeAT\'s database and stores snapshots.',
-    'track_fuel_cmd_note' => 'This command runs automatically every hour via scheduled job. Manual execution is only needed for troubleshooting or immediate updates.',
+    'track_fuel_cmd_title' => 'Track Fuel (Levels + Reserves)',
+    'track_fuel_cmd_desc' => 'Tracks fuel consumption and reserves for all Upwell structures. This command performs two operations: (1) Fuel Bay Tracking - reads fuel bay data (what\'s being consumed), and (2) Reserve Tracking - scans corporation hangars for staged fuel (what\'s in storage). Supports both standard fuel blocks and magmatic gas for Metenox Moon Drills.',
+    'track_fuel_cmd_note' => 'This command runs automatically every hour at :15 past the hour (e.g., 00:15, 01:15, 02:15...). Manual execution is only needed for troubleshooting or immediate updates.',
 
     'analyze_fuel_cmd_title' => 'Analyze Fuel Consumption',
-    'analyze_fuel_cmd_desc' => 'Analyzes fuel bay history to calculate consumption rates, detect anomalies, and identify refuel events.',
-    'analyze_fuel_cmd_note' => 'This command runs automatically every 30 minutes via scheduled job. The analysis uses recent fuel bay snapshots to determine consumption patterns.',
+    'analyze_fuel_cmd_desc' => 'Analyzes fuel bay history to calculate consumption rates, detect anomalies, and identify refuel events. Can analyze all structures, a specific structure, or all structures for a specific corporation.',
+    'analyze_fuel_cmd_note' => 'This command runs automatically every hour at :30 past the hour (e.g., 00:30, 01:30, 02:30...). The analysis uses recent fuel bay snapshots to determine consumption patterns.',
+    'analyze_fuel_cmd_options' => '<strong>Options:</strong>
+    <ul>
+        <li><code>--structure=ID</code> - Analyze a specific structure by ID</li>
+        <li><code>--corporation=ID</code> - Analyze all structures for a specific corporation</li>
+    </ul>
+    <strong>Examples:</strong>
+    <pre><code># Analyze all structures
+php artisan structure-manager:analyze-consumption
 
-    'track_reserves_cmd_title' => 'Track Fuel Reserves',
-    'track_reserves_cmd_desc' => 'Scans all corporation structure hangars for fuel blocks and magmatic gas, storing reserve quantities and locations.',
-    'track_reserves_cmd_note' => 'This command runs automatically every hour via scheduled job. It monitors CorpSAG hangar divisions for staged fuel.',
+# Analyze specific structure
+php artisan structure-manager:analyze-consumption --structure=1234567890
 
-    'create_test_metenox_cmd_title' => 'Create Test Metenox Structures',
+# Analyze all structures for a corporation
+php artisan structure-manager:analyze-consumption --corporation=98765432</code></pre>',
+
+    'cleanup_history_cmd_title' => 'Clean Up Old History',
+    'cleanup_history_cmd_desc' => 'Removes old fuel history records to maintain database performance and save storage space. Cleans up Upwell structure fuel history, POS fuel history, and consumption records.',
+    'cleanup_history_cmd_note' => 'This command runs automatically daily at 3:00 AM. Once deleted, historical data cannot be recovered!',
+    'cleanup_history_cmd_options' => '<strong>Options:</strong>
+    <ul>
+        <li><code>--days=180</code> - Days to retain Upwell structure history (default: 180)</li>
+        <li><code>--pos-days=90</code> - Days to retain POS history (default: 90)</li>
+    </ul>
+    <strong>What gets cleaned:</strong>
+    <ul>
+        <li>Upwell structure fuel history older than specified days</li>
+        <li>POS fuel history older than specified days</li>
+        <li>Structure consumption records older than 6 months</li>
+        <li>POS consumption records older than 3 months</li>
+    </ul>
+    <strong>Examples:</strong>
+    <pre><code># Use defaults (180 days for structures, 90 days for POS)
+php artisan structure-manager:cleanup-history
+
+# Keep 365 days of structure history, 180 days of POS history
+php artisan structure-manager:cleanup-history --days=365 --pos-days=180
+
+# Keep only 30 days of all history
+php artisan structure-manager:cleanup-history --days=30 --pos-days=30</code></pre>',
+
+    'create_test_metenox_cmd_title' => 'Create Test Metenox Structures (Development)',
     'create_test_metenox_cmd_desc' => 'Creates test structures (Metenox Moon Drill + Astrahus) with realistic dual-fuel data for testing and demonstration purposes.',
     'create_test_metenox_cmd_note' => 'This command is designed for testing the plugin\'s Metenox dual-fuel tracking features. It creates:',
     'create_test_metenox_features' => '<ul>
@@ -662,6 +825,74 @@ return [
     'pos_notify_title' => 'POS Low Fuel Notifications',
     'pos_notify_desc' => 'Checks all POSes for low fuel/strontium/charter levels and sends webhook notifications. Runs every 10 minutes via scheduler.',
     'pos_notify_cmd' => 'php artisan structure-manager:notify-pos-fuel',
+
+    'simulate_consumption_title' => 'Simulate Fast Consumption (Development)',
+    'simulate_consumption_desc' => 'Simulates rapid fuel consumption for testing notifications without waiting days. Only works with test POSes created by the create-test-poses command. Reduces fuel levels artificially in 20-minute cycles.',
+    'simulate_consumption_cmd' => 'php artisan structure-manager:simulate-consumption',
+    'simulate_consumption_options' => '<strong>Options:</strong>
+    <ul>
+        <li><code>--cycles=1</code> - Number of 20-minute cycles to simulate (default: 1)</li>
+        <li><code>--test-only</code> - Only process test POSes (IDs >= 1000000000)</li>
+    </ul>
+    <strong>Examples:</strong>
+    <pre><code># Simulate one 20-minute cycle
+php artisan structure-manager:simulate-consumption
+
+# Simulate 10 cycles (simulate ~3.3 hours of consumption)
+php artisan structure-manager:simulate-consumption --cycles=10
+
+# Simulate 72 cycles (simulate 24 hours in ~24 minutes)
+php artisan structure-manager:simulate-consumption --cycles=72</code></pre>
+    <strong>Testing Workflow:</strong>
+    <pre><code># 1. Create test POSes with fast consumption
+php artisan structure-manager:create-test-poses --fast-consumption
+
+# 2. Simulate consumption cycles
+php artisan structure-manager:simulate-consumption --cycles=20
+
+# 3. Trigger notifications
+php artisan structure-manager:notify-pos-fuel
+
+# 4. Cleanup when done
+php artisan structure-manager:create-test-poses --cleanup</code></pre>
+    <div class="warning-box"><i class="fas fa-exclamation-triangle"></i> <strong>Testing Only:</strong> This manipulates fuel levels artificially. Do not use in production!</div>',
+
+    'create_test_poses_title' => 'Create Test POSes (Development)',
+    'create_test_poses_desc' => 'Creates realistic test POSes across multiple corporations for testing webhook filtering, notifications, and fuel consumption scenarios. Uses safe ID ranges far outside EVE\'s data allocation (corporations: 2.1B range, POSes: 2.2B range).',
+    'create_test_poses_cmd' => 'php artisan structure-manager:create-test-poses',
+    'create_test_poses_features' => '<strong>Features:</strong>
+        <ul>
+            <li><strong>Multiple corporations:</strong> Create 1-10 test corporations (default: 3)</li>
+            <li><strong>Multiple POSes per corp:</strong> Add 1-10 POSes to each corporation (default: 2)</li>
+            <li><strong>Varied scenarios:</strong> Automatically creates POSes with different fuel levels (critical, warning, good, zero strontium)</li>
+            <li><strong>Security space variety:</strong> POSes in high-sec (with charters), low-sec, and null-sec systems</li>
+            <li><strong>Tower type diversity:</strong> Various Amarr, Caldari, Gallente, and Minmatar towers (small/medium/large)</li>
+            <li><strong>Fuel reserves:</strong> Automatically creates hangar reserves for testing reserve tracking</li>
+            <li><strong>Fast consumption mode:</strong> Optional 20-minute fuel cycles for rapid testing</li>
+            <li><strong>Complete cleanup:</strong> Easy removal of all test data with --cleanup flag</li>
+        </ul>',
+    'create_test_poses_usage_title' => 'Usage Examples',
+    'create_test_poses_usage' => '<pre><code># Create 3 corporations with 2 POSes each (defaults)
+php artisan structure-manager:create-test-poses
+
+# Create 5 corporations with 4 POSes each
+php artisan structure-manager:create-test-poses --corporations=5 --poses-per-corp=4
+
+# Enable fast consumption for rapid testing (20-min cycles)
+php artisan structure-manager:create-test-poses --fast-consumption
+
+# Remove all test data
+php artisan structure-manager:create-test-poses --cleanup</code></pre>',
+    'create_test_poses_use_cases' => '<strong>Testing Scenarios:</strong>
+        <ul>
+            <li><strong>Webhook filtering:</strong> Create multiple test corporations to verify webhook corporation filters work correctly</li>
+            <li><strong>Notification testing:</strong> Generate POSes at critical/warning fuel levels to test Discord alerts</li>
+            <li><strong>Multiple webhooks:</strong> Test that notifications are sent to correct channels based on corporation filters</li>
+            <li><strong>Fuel consumption:</strong> Use --fast-consumption to verify fuel tracking and calculations</li>
+            <li><strong>Zero strontium behavior:</strong> Test POSes include scenarios with 0 strontium for testing alerts</li>
+            <li><strong>Charter tracking:</strong> High-sec POSes automatically require charters for testing</li>
+            <li><strong>Role mentions:</strong> Test per-webhook role mentions with different corporations</li>
+        </ul>',
 
     'pos_example_title' => 'POS Tracking Example',
     'pos_example_desc' => 'A Large Amarr Control Tower in High Security requires:',
@@ -787,11 +1018,11 @@ return [
         <li><strong>Test webhook:</strong> Use the "Test Webhook" button in Settings to verify connectivity.</li>
         <li><strong>Check notification intervals:</strong> Review fuel and strontium reminder intervals. Set to 0 to disable interval reminders (receive only status change alerts).</li>
         <li><strong>Verify POS status:</strong> Notifications only trigger when POS status changes (good→warning→critical) or during critical interval reminders.</li>
-        <li><strong>Check notification tracking:</strong> Review database table <code>corporation_starbases</code> for columns <code>fuel_last_notification_at</code> and <code>strontium_last_notification_at</code> to see last notification times.</li>
+        <li><strong>Check notification tracking:</strong> Review database table <code>starbase_fuel_history</code> for columns <code>last_fuel_notification_at</code>, <code>last_strontium_notification_at</code>, <code>last_fuel_notification_status</code>, and <code>last_strontium_notification_status</code> to see last notification times and status.</li>
         <li><strong>Inspect scheduler:</strong> Verify that <code>structure-manager:notify-pos-fuel</code> command is running every 10 minutes in SeAT scheduler.</li>
         <li><strong>Review logs:</strong> Check Laravel logs for webhook errors: <code>storage/logs/laravel.log</code></li>
         <li><strong>Validate thresholds:</strong> Ensure critical thresholds are less than warning thresholds in Settings.</li>
-        <li><strong>Discord role mentions:</strong> Verify role ID format is correct: <code>&lt;@&amp;ROLE_ID&gt;</code></li>
+        <li><strong>Per-webhook role mentions:</strong> Verify each webhook\'s role ID format is correct: <code>&lt;@&amp;ROLE_ID&gt;</code></li>
         <li><strong>Final alert timing:</strong> Remember that final alerts are sent at exactly 1 hour remaining, regardless of intervals.</li>
     </ul>',
 

--- a/src/resources/views/help/index.blade.php
+++ b/src/resources/views/help/index.blade.php
@@ -924,6 +924,23 @@
                     {!! trans('structure-manager::help.warning_example') !!}
                 </div>
 
+                <h4><i class="fas fa-radiation"></i> {{ trans('structure-manager::help.zero_strontium_title') }}</h4>
+                <p>{{ trans('structure-manager::help.zero_strontium_intro') }}</p>
+                {!! trans('structure-manager::help.zero_strontium_scenarios') !!}
+                {!! trans('structure-manager::help.zero_strontium_notification_behavior') !!}
+                {!! trans('structure-manager::help.zero_strontium_use_cases') !!}
+
+                <h4><i class="fas fa-project-diagram"></i> {{ trans('structure-manager::help.multiple_webhooks_title') }}</h4>
+                <p>{{ trans('structure-manager::help.multiple_webhooks_intro') }}</p>
+                {!! trans('structure-manager::help.multiple_webhooks_features') !!}
+                {!! trans('structure-manager::help.multiple_webhooks_use_cases') !!}
+                <div class="purple-box">
+                    {!! trans('structure-manager::help.multiple_webhooks_configuration') !!}
+                </div>
+                <div class="info-box">
+                    {!! trans('structure-manager::help.multiple_webhooks_example') !!}
+                </div>
+
                 <div class="info-box">
                     <i class="fas fa-info-circle"></i>
                     <strong>{{ trans('structure-manager::help.upwell_notifications_note') }}:</strong>
@@ -940,6 +957,11 @@
                     {{ trans('structure-manager::help.settings_title') }}
                 </h3>
                 <p>{{ trans('structure-manager::help.settings_intro') }}</p>
+
+                <div class="info-box">
+                    <i class="fas fa-info-circle"></i>
+                    {!! trans('structure-manager::help.settings_notification_note') !!}
+                </div>
 
                 <h4>{{ trans('structure-manager::help.webhook_settings') }}</h4>
                 <p>{{ trans('structure-manager::help.webhook_settings_desc') }}</p>
@@ -1032,6 +1054,11 @@
                 </h3>
                 <p>{{ trans('structure-manager::help.commands_intro') }}</p>
 
+                <div class="info-box">
+                    <i class="fas fa-info-circle"></i>
+                    {!! trans('structure-manager::help.commands_notification_note') !!}
+                </div>
+
                 <h4>{{ trans('structure-manager::help.track_fuel_cmd_title') }}</h4>
                 <p>{{ trans('structure-manager::help.track_fuel_cmd_desc') }}</p>
                 <pre><code>php artisan structure-manager:track-fuel</code></pre>
@@ -1039,13 +1066,15 @@
 
                 <h4>{{ trans('structure-manager::help.analyze_fuel_cmd_title') }}</h4>
                 <p>{{ trans('structure-manager::help.analyze_fuel_cmd_desc') }}</p>
-                <pre><code>php artisan structure-manager:analyze-fuel</code></pre>
+                <pre><code>php artisan structure-manager:analyze-consumption</code></pre>
                 <p>{{ trans('structure-manager::help.analyze_fuel_cmd_note') }}</p>
+                {!! trans('structure-manager::help.analyze_fuel_cmd_options') !!}
 
-                <h4>{{ trans('structure-manager::help.track_reserves_cmd_title') }}</h4>
-                <p>{{ trans('structure-manager::help.track_reserves_cmd_desc') }}</p>
-                <pre><code>php artisan structure-manager:track-reserves</code></pre>
-                <p>{{ trans('structure-manager::help.track_reserves_cmd_note') }}</p>
+                <h4>{{ trans('structure-manager::help.cleanup_history_cmd_title') }}</h4>
+                <p>{{ trans('structure-manager::help.cleanup_history_cmd_desc') }}</p>
+                <pre><code>php artisan structure-manager:cleanup-history</code></pre>
+                <p>{{ trans('structure-manager::help.cleanup_history_cmd_note') }}</p>
+                {!! trans('structure-manager::help.cleanup_history_cmd_options') !!}
 
                 <h4>{{ trans('structure-manager::help.pos_track_fuel_title') }}</h4>
                 <p>{{ trans('structure-manager::help.pos_track_fuel_desc') }}</p>
@@ -1057,9 +1086,27 @@
 
                 <h4>{{ trans('structure-manager::help.pos_notify_title') }}</h4>
                 <p>{{ trans('structure-manager::help.pos_notify_desc') }}</p>
-                <pre><code>php artisan structure-manager:notify-pos-fuel</code></pre>
+                <pre><code>{{ trans('structure-manager::help.pos_notify_cmd') }}</code></pre>
 
-                <h4>{{ trans('structure-manager::help.create_test_metenox_cmd_title') }}</h4>
+                <h4><i class="fas fa-flask"></i> {{ trans('structure-manager::help.simulate_consumption_title') }}</h4>
+                <p>{{ trans('structure-manager::help.simulate_consumption_desc') }}</p>
+                <pre><code>{{ trans('structure-manager::help.simulate_consumption_cmd') }}</code></pre>
+                {!! trans('structure-manager::help.simulate_consumption_options') !!}
+
+                <h4><i class="fas fa-flask"></i> {{ trans('structure-manager::help.create_test_poses_title') }}</h4>
+                <p>{{ trans('structure-manager::help.create_test_poses_desc') }}</p>
+                <pre><code>{{ trans('structure-manager::help.create_test_poses_cmd') }}</code></pre>
+                {!! trans('structure-manager::help.create_test_poses_features') !!}
+                
+                <h5>{{ trans('structure-manager::help.create_test_poses_usage_title') }}</h5>
+                {!! trans('structure-manager::help.create_test_poses_usage') !!}
+                
+                <div class="purple-box">
+                    <i class="fas fa-vial"></i>
+                    {!! trans('structure-manager::help.create_test_poses_use_cases') !!}
+                </div>
+
+                <h4><i class="fas fa-flask"></i> {{ trans('structure-manager::help.create_test_metenox_cmd_title') }}</h4>
                 <p>{{ trans('structure-manager::help.create_test_metenox_cmd_desc') }}</p>
                 <p>{{ trans('structure-manager::help.create_test_metenox_cmd_note') }}</p>
                 {!! trans('structure-manager::help.create_test_metenox_features') !!}

--- a/src/resources/views/reserves.blade.php
+++ b/src/resources/views/reserves.blade.php
@@ -141,7 +141,7 @@
 
 <div class="card refuel-event-card">
     <div class="card-header">
-        <h3 class="card-title">Recent Refuel Events</h3>
+        <h3 class="card-title">Fuel Withdrawals</h3>
         <div class="card-tools">
             <select id="history-days" class="form-control form-control-sm">
                 <option value="7">Last 7 Days</option>
@@ -158,7 +158,7 @@
                         <th>Timestamp</th>
                         <th>System</th>
                         <th>Structure</th>
-                        <th>Blocks Moved</th>
+                        <th>Quantity Withdrawn</th>
                         <th>From Location</th>
                         <th>Fuel Type</th>
                     </tr>
@@ -166,7 +166,7 @@
                 <tbody id="refuel-events-body">
                     <tr>
                         <td colspan="6" class="text-center py-3">
-                            <i class="fas fa-spinner fa-spin"></i> Loading refuel events...
+                            <i class="fas fa-spinner fa-spin"></i> Loading withdrawal events...
                         </td>
                     </tr>
                 </tbody>
@@ -399,7 +399,7 @@ $(document).ready(function() {
         $('#refuel-events-body').html(`
             <tr>
                 <td colspan="6" class="text-center py-3">
-                    <i class="fas fa-spinner fa-spin"></i> Loading refuel events...
+                    <i class="fas fa-spinner fa-spin"></i> Loading withdrawal events...
                 </td>
             </tr>
         `);
@@ -411,7 +411,7 @@ $(document).ready(function() {
             let html = '';
             
             if (data.length === 0) {
-                html = '<tr><td colspan="6" class="text-center py-3"><i class="fas fa-info-circle"></i> No refuel events in this period.</td></tr>';
+                html = '<tr><td colspan="6" class="text-center py-3"><i class="fas fa-info-circle"></i> No withdrawal events in this period.</td></tr>';
             } else {
                 for (const event of data) {
                     const timestamp = new Date(event.timestamp);
@@ -439,11 +439,11 @@ $(document).ready(function() {
             
             $('#refuel-events-body').html(html);
         }).fail(function(xhr, status, error) {
-            console.error('Error loading refuel events:', error);
+            console.error('Error loading withdrawal events:', error);
             $('#refuel-events-body').html(`
                 <tr>
                     <td colspan="6" class="text-center text-danger py-3">
-                        <i class="fas fa-exclamation-triangle"></i> Error loading refuel events: ${error}
+                        <i class="fas fa-exclamation-triangle"></i> Error loading withdrawal events: ${error}
                     </td>
                 </tr>
             `);


### PR DESCRIPTION
## 🆕 Version 1.0.10 — *November 2025*

### Added
- Multiple webhook support with per-webhook configuration (corporation filters, location filters, role mentions)
- Zero strontium behavior handling for POSes (proper critical alerts and status detection)
- Status-based POS notifications (good → warning → critical transitions with optional reminders)
- Final 1-hour alert for POSes before going offline
- `simulate-consumption` command for rapid fuel consumption testing
- Webhook test button in settings for connectivity verification
- Enhanced reserve tracking with nested Office container support

### Changed
- Renamed "Recent Refuel Events" section to "Fuel Withdrawals" for clarity
- Fuel Withdrawals now only shows Upwell structures (excludes POS and Metenox)
- Enhanced refuel event detection logic
- Updated help documentation with corrected command schedules
- `track-fuel` command now documented as handling both fuel bays and reserves
- `analyze-consumption` command now includes `--structure` and `--corporation` options

### Fixed
- POS and Metenox entries incorrectly appearing in Fuel Withdrawals section
- Incorrect command schedules in help documentation (analyze-consumption)
- Duplicate "Track Fuel Reserves" section in help documentation
- Zero strontium alert triggers not working correctly

### Documented
- Added missing `cleanup-history` command documentation
- Added missing `simulate-consumption` command documentation
- Removed confusing duplicate command sections
- Added command options and usage examples throughout
- Corrected all command schedules (hourly at :15/:30, every 10 minutes, etc.)

---