### PR TITLE
Version 1.0.11 - Fix notifications for unanchored/removed POSes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,31 @@ Each version entry lists key changes for easier reference and upgrade planning.
 
 ---
 
-## 🆕 Version 1.0.10 — *November 2025*
+## 🆕 Version 1.0.11 — *January 2026*
+
+### 🐛 Bug Fixes
+
+**Fixed notifications for unanchored/removed POSes**
+
+**Issue:** Users received critical fuel notifications for POSes that had already been unanchored or removed from the game. The POS was not visible in the plugin UI or SeAT, but notifications continued with stale data showing "Last updated 1h ago", "11h ago", etc.
+
+**Root Cause:** The notification job queried historical records (`starbase_fuel_history`) without verifying if the POS still existed in the current corporation holdings (`corporation_starbases`). When a POS was unanchored, it was removed from ESI data but old history records with state=4 (online) remained, triggering repeated notifications.
+
+**What's Fixed:**
+
+- **Added POS existence verification** - Notification job now validates POSes exist in `corporation_starbases` before sending alerts
+- **Primary query filter** - Added `whereExists` clause to exclude POSes no longer in corporation holdings
+- **Secondary safety check** - Per-POS existence verification catches race conditions
+- **Orphaned POS cleanup** - Tracking job now detects and marks removed POSes as unanchored (state=0)
+- **Notification state reset** - Orphaned POSes have all notification tracking fields cleared
+
+**Technical Changes:**
+- `NotifyPosLowFuel.php`: Added DB facade import and existence checks
+- `TrackPosesFuel.php`: Added `cleanupOrphanedPoses()` method that runs after each tracking cycle
+
+---
+
+## Version 1.0.10 — *November 2025*
 
 ### Added
 - Multiple webhook support with per-webhook configuration (corporation filters, location filters, role mentions)

--- a/src/resources/lang/en/help.php
+++ b/src/resources/lang/en/help.php
@@ -1024,6 +1024,7 @@ php artisan structure-manager:create-test-poses --cleanup</code></pre>',
         <li><strong>Validate thresholds:</strong> Ensure critical thresholds are less than warning thresholds in Settings.</li>
         <li><strong>Per-webhook role mentions:</strong> Verify each webhook\'s role ID format is correct: <code>&lt;@&amp;ROLE_ID&gt;</code></li>
         <li><strong>Final alert timing:</strong> Remember that final alerts are sent at exactly 1 hour remaining, regardless of intervals.</li>
+        <li><strong>Notifications for removed POSes:</strong> If you receive alerts for POSes that no longer exist (unanchored/removed), this was fixed in v1.0.11. Update to the latest version. The tracking job now automatically detects and marks orphaned POSes as unanchored.</li>
     </ul>',
 
     'need_help' => 'Need More Help?',


### PR DESCRIPTION
- Add POS existence verification in NotifyPosLowFuel job
- Add whereExists check against corporation_starbases table
- Add secondary per-POS existence check as safety net
- Add cleanupOrphanedPoses() method in TrackPosesFuel job
- Orphaned POSes are now marked as unanchored (state=0)
- Notification tracking is reset for removed POSes
- Update help.php troubleshooting section
- Update CHANGELOG.MD with v1.0.11 entry